### PR TITLE
security(secgate): harden report-write, --apply, and path leaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ sudo ln -sf "$(pwd)/secgate.js" /usr/local/bin/secgate
 # Scan current directory (dry-run, default)
 secgate .
 
-# Scan with auto-remediation
+# Scan with auto-remediation (see warning below)
 secgate . --apply
 
 # Scan with debug output
@@ -93,6 +93,12 @@ secgate . --debug
 
 # Scan specific path
 secgate /path/to/project
+
+# Write reports to a custom directory (default: the target)
+secgate /path/to/project --output-dir /tmp/reports
+
+# Strip absolute paths from the report (auto-on when CI=true)
+secgate /path/to/project --strip-paths
 
 # Show version
 secgate --version
@@ -105,6 +111,23 @@ Exit codes:
 - `0` — PASS (no CRITICAL or HIGH findings)
 - `1` — FAIL (CRITICAL or HIGH findings present)
 - `2` — invalid target or CLI error
+
+---
+
+## Security: `--apply` in untrusted repos
+
+`--apply` executes remediations (`npm audit fix`) inside the scanned repo. Treat this as code execution against the target — only use it on code you trust.
+
+Hardening:
+- SecGate passes `--ignore-scripts` to every npm invocation under `--apply`, so malicious `preinstall`/`postinstall` scripts in the target repo's `package.json` or its dependencies are not executed.
+- `--apply` is gated: it refuses to run unless either `SECGATE_CONFIRM_APPLY=1` is set (for CI/non-interactive use) or the user confirms `y` at an interactive TTY prompt.
+- Every `--apply` execution is recorded in the report's `auditLog` field and mirrored to stderr with timestamp + target.
+
+Guidance:
+- **Do not run `--apply` against untrusted or newly cloned third-party repos.** Run scans in dry-run mode first, review findings, then decide.
+- In CI, prefer dry-run (`secgate .`) and rely on the exit code to gate the pipeline. Only use `--apply` with `SECGATE_CONFIRM_APPLY=1` inside an isolated, ephemeral runner.
+- Report files default to the target directory. Use `--output-dir` to redirect explicitly; a warning is printed to stderr when `cwd !== target`.
+- In CI, `--strip-paths` is auto-enabled to prevent host paths from leaking into uploaded artifacts.
 
 ---
 
@@ -184,14 +207,22 @@ Each run writes two files:
       "patch": {
         "action": "...",
         "cmd": "display string or null",
-        "exec": { "binary": "npm", "args": ["audit", "fix"], "cwd": "..." }
+        "exec": { "binary": "npm", "args": ["audit", "fix", "--ignore-scripts"], "cwd": "..." }
       }
     }],
     "stagedChanges": [],
     "executed": [],
     "blocked": [],
     "confidence": 100
-  }
+  },
+  "auditLog": [
+    {
+      "timestamp": "ISO 8601",
+      "event": "apply_start | apply_confirmed | apply_exec | apply_ok | apply_fail",
+      "target": "target path or repo basename (if --strip-paths)",
+      "...": "event-specific fields"
+    }
+  ]
 }
 ```
 

--- a/secgate.js
+++ b/secgate.js
@@ -28,13 +28,22 @@ Usage:
   secgate [target] [options]
 
 Arguments:
-  target          Directory to scan (default: current directory)
+  target              Directory to scan (default: current directory)
 
 Options:
-  --apply         Execute fixable remediations (default: dry-run)
-  --debug         Print raw scanner output
-  --version, -v   Print version and exit
-  --help, -h      Show this help
+  --apply             Execute fixable remediations (default: dry-run).
+                      Requires SECGATE_CONFIRM_APPLY=1 or an interactive
+                      y/n confirmation. Runs npm with --ignore-scripts.
+  --output-dir <dir>  Directory to write report files (default: target)
+  --strip-paths       Relativize target to repo basename in the report.
+                      Auto-enabled when CI=true.
+  --debug             Print raw scanner output
+  --version, -v       Print version and exit
+  --help, -h          Show this help
+
+Environment:
+  SECGATE_CONFIRM_APPLY=1   Non-interactive confirmation for --apply
+  CI=true                   Auto-enables --strip-paths
 
 Exit codes:
   0  PASS — no CRITICAL or HIGH findings
@@ -48,9 +57,19 @@ Output:
   process.exit(0);
 }
 
+function argValue(flag) {
+  const i = argv.indexOf(flag);
+  if (i === -1) return null;
+  const v = argv[i + 1];
+  if (!v || v.startsWith("--")) return null;
+  return v;
+}
+
 const rawTarget = argv[0] && !argv[0].startsWith("--") ? argv[0] : ".";
 const APPLY = argv.includes("--apply");
 const DEBUG = argv.includes("--debug");
+const STRIP_PATHS = argv.includes("--strip-paths") || process.env.CI === "true";
+const OUTPUT_DIR_FLAG = argValue("--output-dir");
 
 const target = path.resolve(rawTarget);
 
@@ -63,7 +82,37 @@ if (!fs.statSync(target).isDirectory()) {
   process.exit(2);
 }
 
-const outputFile = "secgate-v7-report.json";
+const outputDir = OUTPUT_DIR_FLAG
+  ? path.resolve(OUTPUT_DIR_FLAG)
+  : target;
+
+if (!OUTPUT_DIR_FLAG) {
+  // Default output must live under the target — never leak to cwd.
+  if (process.cwd() !== target) {
+    console.error(
+      `Warning: cwd (${process.cwd()}) differs from target (${target}); ` +
+        `writing reports to target. Use --output-dir to override.`
+    );
+  }
+} else {
+  if (!fs.existsSync(outputDir)) {
+    try {
+      fs.mkdirSync(outputDir, { recursive: true });
+    } catch (e) {
+      console.error(`Cannot create --output-dir ${outputDir}: ${e.message}`);
+      process.exit(2);
+    }
+  }
+  if (!fs.statSync(outputDir).isDirectory()) {
+    console.error(`--output-dir is not a directory: ${outputDir}`);
+    process.exit(2);
+  }
+}
+
+const repoName = path.basename(path.resolve(target));
+const reportTarget = STRIP_PATHS ? repoName : target;
+
+const outputFile = path.join(outputDir, "secgate-v7-report.json");
 
 /* -----------------------------
    STATE
@@ -84,7 +133,7 @@ const toolStatus = {
 const report = {
   version: pkg.version,
   timestamp: new Date().toISOString(),
-  target,
+  target: reportTarget,
   mode: APPLY ? "apply" : "dry-run",
   status: "PASS",
 
@@ -106,8 +155,34 @@ const report = {
     executed: [],
     blocked: [],
     confidence: 100
-  }
+  },
+
+  auditLog: []
 };
+
+function auditLog(event, detail) {
+  const entry = {
+    timestamp: new Date().toISOString(),
+    event,
+    target: reportTarget,
+    ...detail
+  };
+  report.auditLog.push(entry);
+  console.error(`[audit] ${JSON.stringify(entry)}`);
+}
+
+function stripAbsolutePaths(s) {
+  if (!STRIP_PATHS || typeof s !== "string") return s;
+  // Replace any occurrence of the absolute target path with the repo basename.
+  const abs = target;
+  let out = s.split(abs).join(repoName);
+  // Also scrub parent dir paths that might appear via tools.
+  const parent = path.dirname(abs);
+  if (parent && parent !== "/" && parent !== ".") {
+    out = out.split(parent + path.sep).join("");
+  }
+  return out;
+}
 
 /* -----------------------------
    UTILS
@@ -432,8 +507,12 @@ function patch(f) {
   if (f.tool === "npm") {
     return {
       action: "npm audit fix",
-      cmd: `npm audit fix (cwd=${target})`,
-      exec: { binary: "npm", args: ["audit", "fix"], cwd: target }
+      cmd: `npm audit fix --ignore-scripts (cwd=${reportTarget})`,
+      exec: {
+        binary: "npm",
+        args: ["audit", "fix", "--ignore-scripts"],
+        cwd: target
+      }
     };
   }
 
@@ -490,11 +569,30 @@ function remediate(findings) {
       staged.push(p);
 
       if (APPLY) {
+        auditLog("apply_exec", {
+          tool: f.tool,
+          signature: f.signature,
+          binary: p.exec.binary,
+          args: p.exec.args,
+          cwd: p.exec.cwd
+        });
         try {
-          runTool(p.exec.binary, p.exec.args, { cwd: p.exec.cwd });
+          runTool(p.exec.binary, p.exec.args, {
+            cwd: p.exec.cwd,
+            env: { ...process.env, npm_config_ignore_scripts: "true" }
+          });
           executed.push(p.action);
-        } catch {
+          auditLog("apply_ok", {
+            tool: f.tool,
+            signature: f.signature
+          });
+        } catch (e) {
           blocked.push(p);
+          auditLog("apply_fail", {
+            tool: f.tool,
+            signature: f.signature,
+            error: String(e && e.message ? e.message : e)
+          });
         }
       }
     }
@@ -800,10 +898,48 @@ function renderHtml(rep, repoName) {
    PIPELINE
 ------------------------------*/
 
+function confirmApplyOrExit() {
+  if (!APPLY) return;
+  if (process.env.SECGATE_CONFIRM_APPLY === "1") {
+    auditLog("apply_confirmed", { via: "env" });
+    return;
+  }
+  if (process.stdin.isTTY) {
+    process.stderr.write(
+      `\nSecGate --apply will execute remediations against:\n  ${target}\n` +
+        `npm invocations run with --ignore-scripts. Proceed? [y/N] `
+    );
+    let answer = "";
+    try {
+      const buf = Buffer.alloc(8);
+      const n = fs.readSync(0, buf, 0, buf.length, null);
+      answer = buf.slice(0, n).toString("utf-8").trim().toLowerCase();
+    } catch {
+      answer = "";
+    }
+    if (answer !== "y" && answer !== "yes") {
+      console.error("Aborted: --apply not confirmed.");
+      process.exit(2);
+    }
+    auditLog("apply_confirmed", { via: "tty" });
+    return;
+  }
+  console.error(
+    "Refusing to run --apply without confirmation. " +
+      "Set SECGATE_CONFIRM_APPLY=1 or run in a TTY."
+  );
+  process.exit(2);
+}
+
 console.log("\nSEC GATE v7 - AI SOC ENGINE");
-console.log("Target:", target);
+console.log("Target:", reportTarget);
 console.log("Mode:", APPLY ? "APPLY" : "DRY RUN");
 console.log("--------------------------------");
+
+confirmApplyOrExit();
+if (APPLY) {
+  auditLog("apply_start", { outputDir });
+}
 
 semgrep();
 gitleaks();
@@ -862,10 +998,41 @@ if (APPLY) {
   report.remediation.executed.forEach(e => console.log("-", e));
 }
 
+if (STRIP_PATHS) {
+  for (const f of report.findings) {
+    if (f.signature) f.signature = stripAbsolutePaths(f.signature);
+    if (f.message) f.message = stripAbsolutePaths(f.message);
+    if (f.file) f.file = stripAbsolutePaths(f.file);
+  }
+  for (const r of report.intelligence.reasoning || []) {
+    if (r.issue) r.issue = stripAbsolutePaths(r.issue);
+    if (r.why) r.why = stripAbsolutePaths(r.why);
+  }
+  for (const p of report.remediation.plan || []) {
+    if (p.issue) p.issue = stripAbsolutePaths(p.issue);
+    if (p.patch) {
+      if (p.patch.cmd) p.patch.cmd = stripAbsolutePaths(p.patch.cmd);
+      if (p.patch.exec && p.patch.exec.cwd) {
+        p.patch.exec.cwd = stripAbsolutePaths(p.patch.exec.cwd);
+      }
+    }
+  }
+  for (const p of report.remediation.stagedChanges || []) {
+    if (p.cmd) p.cmd = stripAbsolutePaths(p.cmd);
+    if (p.exec && p.exec.cwd) p.exec.cwd = stripAbsolutePaths(p.exec.cwd);
+  }
+  for (const p of report.remediation.blocked || []) {
+    if (p.cmd) p.cmd = stripAbsolutePaths(p.cmd);
+    if (p.exec && p.exec.cwd) p.exec.cwd = stripAbsolutePaths(p.exec.cwd);
+  }
+  for (const a of report.auditLog || []) {
+    if (a.cwd) a.cwd = stripAbsolutePaths(a.cwd);
+  }
+}
+
 fs.writeFileSync(outputFile, JSON.stringify(report, null, 2));
 
-const repoName = path.basename(path.resolve(target));
-const htmlFile = `${repoName}.html`;
+const htmlFile = path.join(outputDir, `${repoName}.html`);
 fs.writeFileSync(htmlFile, renderHtml(report, repoName));
 
 console.log("\nReport saved:", outputFile);

--- a/test/fixtures/malicious-postinstall/package.json
+++ b/test/fixtures/malicious-postinstall/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "malicious-postinstall-fixture",
+  "version": "0.0.1",
+  "private": true,
+  "description": "Fixture: a postinstall script that would leak PWNED to /tmp if executed. SecGate --apply must NOT trigger it.",
+  "scripts": {
+    "postinstall": "echo PWNED > /tmp/secgate-pwned",
+    "preinstall": "echo PWNED > /tmp/secgate-pwned",
+    "install": "echo PWNED > /tmp/secgate-pwned"
+  },
+  "dependencies": {
+    "left-pad": "0.0.1"
+  }
+}

--- a/test/smoke.mjs
+++ b/test/smoke.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { execFileSync } from "child_process";
+import { spawnSync } from "child_process";
 import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
@@ -13,21 +13,18 @@ let passed = 0;
 let failed = 0;
 
 function run(args, opts = {}) {
-  try {
-    const stdout = execFileSync("node", [bin, ...args], {
-      encoding: "utf-8",
-      stdio: "pipe",
-      cwd: opts.cwd || repoRoot,
-      ...opts
-    });
-    return { code: 0, stdout, stderr: "" };
-  } catch (e) {
-    return {
-      code: e.status ?? 1,
-      stdout: (e.stdout || "").toString(),
-      stderr: (e.stderr || "").toString()
-    };
-  }
+  const res = spawnSync("node", [bin, ...args], {
+    encoding: "utf-8",
+    cwd: opts.cwd || repoRoot,
+    env: opts.env || process.env,
+    input: opts.input,
+    maxBuffer: 64 * 1024 * 1024
+  });
+  return {
+    code: res.status ?? 1,
+    stdout: (res.stdout || "").toString(),
+    stderr: (res.stderr || "").toString()
+  };
 }
 
 function test(name, fn) {
@@ -135,6 +132,121 @@ test("HTML report contains all 5 tool tabs", () => {
   }
   fs.unlinkSync(path.join(fixture, "secgate-v7-report.json"));
   fs.unlinkSync(path.join(fixture, "clean.html"));
+});
+
+test("scan from /tmp writes no report files to /tmp", () => {
+  const fixture = path.join(repoRoot, "test/fixtures/clean");
+  const tmpBefore = fs.readdirSync("/tmp");
+  const r = run([fixture], { cwd: "/tmp" });
+  assertEq(r.code, 0, "exit");
+  const tmpAfter = fs.readdirSync("/tmp");
+  const added = tmpAfter.filter(n => !tmpBefore.includes(n));
+  const leaked = added.filter(n => /secgate|\.html$/.test(n));
+  if (leaked.length) {
+    throw new Error(`report files leaked to /tmp: ${leaked.join(",")}`);
+  }
+  // Files must be in the fixture (target), not /tmp.
+  const json = path.join(fixture, "secgate-v7-report.json");
+  const html = path.join(fixture, "clean.html");
+  if (!fs.existsSync(json)) throw new Error(`missing ${json}`);
+  if (!fs.existsSync(html)) throw new Error(`missing ${html}`);
+  fs.unlinkSync(json);
+  fs.unlinkSync(html);
+  // cwd-mismatch warning must fire.
+  assertContains(r.stderr, "differs from target", "cwd warning");
+});
+
+test("--apply on malicious postinstall does NOT execute lifecycle scripts", () => {
+  const fixture = path.join(repoRoot, "test/fixtures/malicious-postinstall");
+  const pwned = "/tmp/secgate-pwned";
+  if (fs.existsSync(pwned)) fs.unlinkSync(pwned);
+
+  const r = run([fixture, "--apply"], {
+    cwd: fixture,
+    env: { ...process.env, SECGATE_CONFIRM_APPLY: "1" }
+  });
+
+  // Whatever the exit status (scan may FAIL on HIGH findings), the postinstall
+  // script must never have run.
+  if (fs.existsSync(pwned)) {
+    const contents = fs.readFileSync(pwned, "utf-8");
+    fs.unlinkSync(pwned);
+    throw new Error(`postinstall executed — /tmp/secgate-pwned: ${contents}`);
+  }
+
+  // Audit log must record the apply attempt.
+  const json = path.join(fixture, "secgate-v7-report.json");
+  if (fs.existsSync(json)) {
+    const rep = JSON.parse(fs.readFileSync(json, "utf-8"));
+    if (!Array.isArray(rep.auditLog)) {
+      throw new Error("missing auditLog in report");
+    }
+    const hasApplyStart = rep.auditLog.some(a => a.event === "apply_start");
+    if (!hasApplyStart) {
+      throw new Error("auditLog missing apply_start entry");
+    }
+    fs.unlinkSync(json);
+  }
+  const html = path.join(fixture, "malicious-postinstall.html");
+  if (fs.existsSync(html)) fs.unlinkSync(html);
+
+  // stderr must contain audit trail entries.
+  assertContains(r.stderr, "[audit]", "stderr audit trail");
+});
+
+test("--apply refuses without confirmation (no TTY, no env)", () => {
+  const fixture = path.join(repoRoot, "test/fixtures/clean");
+  const env = { ...process.env };
+  delete env.SECGATE_CONFIRM_APPLY;
+  const r = run([fixture, "--apply"], { cwd: fixture, env });
+  assertEq(r.code, 2, "exit");
+  assertContains(r.stderr, "confirmation", "refusal stderr");
+  // Report files must not exist (run aborted pre-scan).
+  const json = path.join(fixture, "secgate-v7-report.json");
+  if (fs.existsSync(json)) fs.unlinkSync(json);
+  const html = path.join(fixture, "clean.html");
+  if (fs.existsSync(html)) fs.unlinkSync(html);
+});
+
+test("CI=true report JSON contains no absolute target path", () => {
+  const fixture = path.join(repoRoot, "test/fixtures/clean");
+  const r = run([fixture], {
+    cwd: fixture,
+    env: { ...process.env, CI: "true" }
+  });
+  assertEq(r.code, 0, "exit");
+  const json = path.join(fixture, "secgate-v7-report.json");
+  const raw = fs.readFileSync(json, "utf-8");
+  const rep = JSON.parse(raw);
+  assertEq(rep.target, "clean", "target relativized");
+  if (raw.includes(fixture)) {
+    throw new Error(`absolute fixture path leaked into JSON: ${fixture}`);
+  }
+  // Accept /tmp (POSIX root-like) but reject the fixture's absolute root.
+  if (/"\/Users\/[^"]+"/.test(raw) || /"\/home\/[^"]+"/.test(raw)) {
+    throw new Error("absolute user-home path leaked into JSON");
+  }
+  fs.unlinkSync(json);
+  fs.unlinkSync(path.join(fixture, "clean.html"));
+});
+
+test("--output-dir writes reports to the given directory", () => {
+  const fixture = path.join(repoRoot, "test/fixtures/clean");
+  const out = fs.mkdtempSync("/tmp/secgate-out-");
+  const r = run([fixture, "--output-dir", out], { cwd: fixture });
+  assertEq(r.code, 0, "exit");
+  const json = path.join(out, "secgate-v7-report.json");
+  const html = path.join(out, "clean.html");
+  if (!fs.existsSync(json)) throw new Error(`missing ${json}`);
+  if (!fs.existsSync(html)) throw new Error(`missing ${html}`);
+  fs.unlinkSync(json);
+  fs.unlinkSync(html);
+  fs.rmdirSync(out);
+  // Fixture dir must NOT contain the report.
+  if (fs.existsSync(path.join(fixture, "secgate-v7-report.json"))) {
+    fs.unlinkSync(path.join(fixture, "secgate-v7-report.json"));
+    throw new Error("report also written to target when --output-dir given");
+  }
 });
 
 console.log("-------------------");


### PR DESCRIPTION
## Summary

Closes #29.

Hardens three critical paths in `secgate.js`:

- **Path traversal fix**: reports default to the target directory, not `process.cwd()`. Added `--output-dir <dir>` flag. A stderr warning is emitted when `cwd !== target` and `--output-dir` is not set. `--output-dir` is created (recursively) when missing and validated as a directory.
- **`--apply` RCE mitigation**: every npm invocation under `--apply` now runs with `--ignore-scripts` (flag + `npm_config_ignore_scripts=true` in env as belt-and-suspenders). `--apply` is refused unless `SECGATE_CONFIRM_APPLY=1` is set or the user answers `y` at an interactive TTY prompt. Every apply-path event (`apply_start`, `apply_confirmed`, `apply_exec`, `apply_ok`, `apply_fail`) is written to stderr and to a new `auditLog` field on the report JSON with ISO 8601 timestamp and target.
- **Strip absolute paths**: new `--strip-paths` flag (auto-enabled when `process.env.CI === "true"`) relativizes `rep.target` to the repo basename and scrubs absolute path occurrences from finding signatures/messages, reasoning, remediation plans, staged/blocked items, and audit-log `cwd` fields.

README gains a `Security: --apply in untrusted repos` section documenting the gate, the `--ignore-scripts` guarantee, and operational guidance (dry-run first in untrusted repos; ephemeral runners only for CI `--apply`).

## Test plan

New fixture `test/fixtures/malicious-postinstall/` with a `postinstall: "echo PWNED > /tmp/secgate-pwned"` entry. Smoke suite grew from 9 to 14 tests:

- [x] Scan from `/tmp` against the clean fixture — no report files written to `/tmp`; the cwd-mismatch warning fires on stderr; reports land in the target.
- [x] `--apply` against `malicious-postinstall` (with `SECGATE_CONFIRM_APPLY=1`) — `/tmp/secgate-pwned` is never created; `auditLog` contains an `apply_start` entry; stderr carries `[audit]` lines.
- [x] `--apply` without confirmation (no TTY, no env var) — exits 2, writes no report, stderr says `confirmation`.
- [x] `CI=true` — `rep.target === "clean"`, raw JSON contains no `/Users/...` or `/home/...` absolute paths.
- [x] `--output-dir /tmp/secgate-out-XXXX` — reports land in the given dir; target dir stays clean.
- [x] All 9 existing smoke tests still pass (version/help, target validation, clean fixture, vulnerable-dockerfile, command-injection regression, HTML tabs).

Run: `npm test` (14/14 green).