### PR TITLE
feat(secgate): overhaul findings schema with location + severity

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,8 @@ Each run writes two files:
     "critical": 0,
     "high": 0,
     "medium": 0,
-    "low": 0
+    "low": 0,
+    "unknown": 0
   },
   "tools": {
     "semgrep":  "ran | clean | skipped | error | pending",
@@ -166,10 +167,15 @@ Each run writes two files:
     {
       "tool": "gitleaks | semgrep | npm | osv | trivy",
       "type": "secret | code | dependency | iac | license",
-      "severity": "CRITICAL | HIGH | MEDIUM | LOW",
+      "severity": "CRITICAL | HIGH | MEDIUM | LOW | UNKNOWN",
       "signature": "rule or package ID",
       "message": "description",
-      "fixable": true
+      "file": "relative or absolute path, or null",
+      "line": 42,
+      "col": 5,
+      "endLine": 42,
+      "fixable": false,
+      "fixableBy": "auto | manual | null"
     }
   ],
   "intelligence": {
@@ -194,6 +200,22 @@ Each run writes two files:
   }
 }
 ```
+
+### Severity tiers
+
+Every finding is normalized to one of 5 tiers at the `addFinding()` ingress:
+
+- **CRITICAL** — exploitable now (secrets, CVSS ≥ 9, hardcoded-credential SAST rules)
+- **HIGH** — high-impact (CVSS 7.0–8.9, Semgrep `ERROR`, rated `HIGH` upstream)
+- **MEDIUM** — meaningful (CVSS 4.0–6.9, `WARNING`, `MODERATE`)
+- **LOW** — informational (CVSS < 4.0, `INFO`, `NOTE`)
+- **UNKNOWN** — upstream provided no severity or an unrecognized value; surfaced explicitly rather than silently miscounted
+
+### Fixability
+
+- `fixableBy: "auto"` — `patch()` returns an executable command; `--apply` will run it (currently only `npm audit fix`).
+- `fixableBy: "manual"` — a patch exists but requires human action (upgrade, rotate, refactor).
+- `fixable: true` mirrors `fixableBy === "auto"` for CI convenience.
 
 ### Tool states
 

--- a/package.json
+++ b/package.json
@@ -47,7 +47,9 @@
     "provenance": true
   },
   "scripts": {
-    "test": "node test/smoke.mjs",
+    "test": "node test/smoke.mjs && node test/schema.mjs",
+    "test:smoke": "node test/smoke.mjs",
+    "test:schema": "node test/schema.mjs",
     "scan": "node secgate.js ."
   }
 }

--- a/secgate.js
+++ b/secgate.js
@@ -88,7 +88,7 @@ const report = {
   mode: APPLY ? "apply" : "dry-run",
   status: "PASS",
 
-  summary: { critical: 0, high: 0, medium: 0, low: 0 },
+  summary: { critical: 0, high: 0, medium: 0, low: 0, unknown: 0 },
 
   findings: [],
   tools: toolStatus,
@@ -142,14 +142,40 @@ function debug(label, data) {
   }
 }
 
+const SEVERITY_TIERS = ["CRITICAL", "HIGH", "MEDIUM", "LOW", "UNKNOWN"];
+
+function normalizeSeverity(raw) {
+  if (raw == null) return "UNKNOWN";
+  const v = String(raw).trim().toUpperCase();
+  if (v === "MODERATE") return "MEDIUM";
+  if (v === "WARNING") return "MEDIUM";
+  if (v === "ERROR") return "HIGH";
+  if (v === "INFO" || v === "NOTE" || v === "INFORMATIONAL") return "LOW";
+  if (v === "NEGLIGIBLE") return "LOW";
+  return SEVERITY_TIERS.includes(v) ? v : "UNKNOWN";
+}
+
 function addFinding(f) {
+  const severity = normalizeSeverity(f.severity);
+  const fixableBy =
+    f.fixableBy === "auto" || f.fixableBy === "manual"
+      ? f.fixableBy
+      : f.fixable
+      ? "manual"
+      : null;
+
   findings.push({
     tool: f.tool,
     type: f.type,
-    severity: f.severity,
+    severity,
     signature: f.signature,
     message: f.message,
-    fixable: f.fixable || false
+    file: f.file ?? null,
+    line: f.line ?? null,
+    col: f.col ?? null,
+    endLine: f.endLine ?? null,
+    fixable: fixableBy === "auto",
+    fixableBy
   });
 }
 
@@ -180,7 +206,10 @@ function gitleaks() {
         severity: "CRITICAL",
         signature: item.RuleID,
         message: item.Description,
-        fixable: false
+        file: item.File ?? null,
+        line: item.StartLine ?? null,
+        endLine: item.EndLine ?? null,
+        fixableBy: "manual"
       });
     });
 
@@ -188,6 +217,34 @@ function gitleaks() {
   } catch {
     toolStatus.gitleaks = "error";
   }
+}
+
+const SEMGREP_TIER = {
+  ERROR: "HIGH",
+  WARNING: "MEDIUM",
+  INFO: "LOW",
+  NOTE: "LOW"
+};
+
+const SECRET_RE = /(secret|credential|password|token|api[_-]?key|hardcoded)/i;
+const SECRET_CWES = ["CWE-798", "CWE-259", "CWE-321", "CWE-522", "CWE-798:"];
+
+function semgrepSeverity(r) {
+  const base = SEMGREP_TIER[(r.extra?.severity || "").toUpperCase()] || "MEDIUM";
+
+  const meta = r.extra?.metadata || {};
+  const category = String(meta.category || "").toLowerCase();
+  const checkId = String(r.check_id || "");
+  const cweArr = []
+    .concat(meta.cwe || [])
+    .concat(meta.owasp || [])
+    .map(x => String(x));
+
+  const isSecret =
+    (category === "security" && SECRET_RE.test(checkId + " " + JSON.stringify(meta))) ||
+    cweArr.some(c => SECRET_CWES.some(sc => c.toUpperCase().includes(sc)));
+
+  return isSecret ? "CRITICAL" : base;
 }
 
 function semgrep() {
@@ -208,10 +265,14 @@ function semgrep() {
       addFinding({
         tool: "semgrep",
         type: "code",
-        severity: r.extra.severity === "ERROR" ? "HIGH" : "MEDIUM",
+        severity: semgrepSeverity(r),
         signature: r.check_id,
-        message: r.extra.message,
-        fixable: true
+        message: r.extra?.message,
+        file: r.path ?? null,
+        line: r.start?.line ?? null,
+        col: r.start?.col ?? null,
+        endLine: r.end?.line ?? null,
+        fixableBy: "manual"
       });
     });
 
@@ -222,10 +283,61 @@ function semgrep() {
 }
 
 function severityFromCvss(score) {
+  if (!Number.isFinite(score) || score <= 0) return null;
   if (score >= 9) return "CRITICAL";
   if (score >= 7) return "HIGH";
   if (score >= 4) return "MEDIUM";
   return "LOW";
+}
+
+function cvssBaseScore(vec) {
+  // OSV stores either a bare vector ("CVSS:3.1/AV:N/...") with no score,
+  // or a prefixed score ("7.5/CVSS:3.1/..."). Strip the CVSS version prefix
+  // first so we don't mistake "3.1" for the base score.
+  const stripped = String(vec || "").replace(/CVSS:\d+\.\d+\/?/, "");
+  const m = stripped.match(/(?:^|[^\d])(\d+(?:\.\d+)?)/);
+  return m ? parseFloat(m[1]) : NaN;
+}
+
+function ratingFromText(txt) {
+  const s = String(txt || "").toUpperCase();
+  if (/\bCRITICAL\b/.test(s)) return "CRITICAL";
+  if (/\bHIGH\b/.test(s)) return "HIGH";
+  if (/\b(MODERATE|MEDIUM)\b/.test(s)) return "MEDIUM";
+  if (/\bLOW\b/.test(s)) return "LOW";
+  return null;
+}
+
+function osvSeverity(v) {
+  // 1. CVSS numeric score — prefer V3, fall back to V2.
+  const sev = v.severity || [];
+  let best = 0;
+  for (const s of sev) {
+    const t = (s.type || "").toUpperCase();
+    if (t === "CVSS_V3" || t === "CVSS_V2") {
+      const score = cvssBaseScore(s.score);
+      if (Number.isFinite(score)) best = Math.max(best, score);
+    }
+  }
+  const bySeverity = severityFromCvss(best);
+  if (bySeverity) return bySeverity;
+
+  // 2. database_specific.severity rating string
+  const dbSev = v.database_specific?.severity;
+  const byDb = ratingFromText(dbSev);
+  if (byDb) return byDb;
+
+  // 3. Any rating text on severity entries
+  for (const s of sev) {
+    const byText = ratingFromText(s.type) || ratingFromText(s.score);
+    if (byText) return byText;
+  }
+
+  // 4. Advisory body / details as last resort.
+  const byDetails = ratingFromText(v.details);
+  if (byDetails) return byDetails;
+
+  return "UNKNOWN";
 }
 
 function osvScanner() {
@@ -248,22 +360,22 @@ function osvScanner() {
     const before = findings.length;
 
     for (const r of results) {
+      const lockFile = r.source?.path || null;
+
       for (const p of r.packages || []) {
         const pkgName = p.package?.name || "unknown";
         const pkgEco = p.package?.ecosystem || "unknown";
 
         for (const v of p.vulnerabilities || []) {
-          const cvss = (v.severity || [])
-            .map(s => parseFloat(s.score?.match(/\d+\.\d+/)?.[0] || "0"))
-            .reduce((a, b) => Math.max(a, b), 0);
-
           addFinding({
             tool: "osv",
             type: "dependency",
-            severity: severityFromCvss(cvss),
+            severity: osvSeverity(v),
             signature: `${pkgEco}:${pkgName}@${v.id}`,
             message: v.summary || v.id,
-            fixable: true
+            file: lockFile || pkgName,
+            line: null,
+            fixableBy: "manual"
           });
         }
       }
@@ -299,10 +411,13 @@ function trivy() {
         addFinding({
           tool: "trivy",
           type: "iac",
-          severity: (m.Severity || "MEDIUM").toUpperCase(),
+          severity: m.Severity,
           signature: `${m.ID}:${r.Target}`,
           message: m.Title || m.Description || m.ID,
-          fixable: false
+          file: r.Target ?? null,
+          line: m.CauseMetadata?.StartLine ?? null,
+          endLine: m.CauseMetadata?.EndLine ?? null,
+          fixableBy: "manual"
         });
       }
 
@@ -310,10 +425,12 @@ function trivy() {
         addFinding({
           tool: "trivy",
           type: "license",
-          severity: (l.Severity || "LOW").toUpperCase(),
+          severity: l.Severity,
           signature: `${l.Name}:${l.PkgName || r.Target}`,
           message: `License ${l.Name} flagged for ${l.PkgName || r.Target}`,
-          fixable: false
+          file: l.FilePath || r.Target || null,
+          line: null,
+          fixableBy: "manual"
         });
       }
     }
@@ -348,21 +465,21 @@ function npmAudit() {
     const vulns = json.vulnerabilities || {};
     const before = findings.length;
 
+    const lockFile = ["package-lock.json", "npm-shrinkwrap.json", "yarn.lock"]
+      .find(f => fs.existsSync(path.join(target, f))) || "package.json";
+
     for (const k in vulns) {
       const v = vulns[k];
 
       addFinding({
         tool: "npm",
         type: "dependency",
-        severity:
-          v.severity === "critical"
-            ? "CRITICAL"
-            : v.severity === "high"
-            ? "HIGH"
-            : "MEDIUM",
+        severity: v.severity,
         signature: k,
-        message: v.title,
-        fixable: true
+        message: v.title || v.name || k,
+        file: lockFile,
+        line: null,
+        fixableBy: "auto"
       });
     }
 
@@ -390,7 +507,9 @@ function analyze(findings) {
         ? 6
         : f.severity === "MEDIUM"
         ? 3
-        : 1;
+        : f.severity === "LOW"
+        ? 1
+        : 0;
 
     risk += weight;
     surface.add(f.type);
@@ -528,8 +647,24 @@ function sevColor(sev) {
     CRITICAL: "#ff3b30",
     HIGH: "#ff9500",
     MEDIUM: "#ffcc00",
-    LOW: "#34c759"
+    LOW: "#34c759",
+    UNKNOWN: "#8e8e93"
   }[sev] || "#8e8e93";
+}
+
+function formatLocation(f) {
+  if (!f.file) return "";
+  const rel = f.file;
+  const lineFrag = f.line != null ? `:${f.line}` : "";
+  const colFrag = f.col != null ? `:${f.col}` : "";
+  const label = `${rel}${lineFrag}${colFrag}`;
+  // file:// link only when we have an absolute-looking path
+  const isAbs = rel.startsWith("/") || /^[a-zA-Z]:[\\/]/.test(rel);
+  if (isAbs) {
+    const href = `file://${rel}${f.line != null ? `#L${f.line}` : ""}`;
+    return `<a href="${escapeHtml(href)}" class="loc">${escapeHtml(label)}</a>`;
+  }
+  return `<span class="loc">${escapeHtml(label)}</span>`;
 }
 
 function renderHtml(rep, repoName) {
@@ -570,8 +705,9 @@ function renderHtml(rep, repoName) {
           <td><span class="pill" style="background:${sevColor(f.severity)}">${e(f.severity)}</span></td>
           <td>${e(f.type)}</td>
           <td class="mono">${e(f.signature)}</td>
+          <td class="mono">${formatLocation(f) || '<span class="empty">—</span>'}</td>
           <td>${e(f.message)}</td>
-          <td>${f.fixable ? "yes" : "no"}</td>
+          <td>${f.fixableBy === "auto" ? "auto" : f.fixableBy === "manual" ? "manual" : "no"}</td>
         </tr>`
       )
       .join("");
@@ -593,7 +729,7 @@ function renderHtml(rep, repoName) {
       return `<div class="empty success">${e(TOOL_LABEL[tool])} scanned the target and found no issues.</div>`;
     }
     return `<table>
-      <thead><tr><th>Severity</th><th>Type</th><th>Signature</th><th>Message</th><th>Fixable</th></tr></thead>
+      <thead><tr><th>Severity</th><th>Type</th><th>Signature</th><th>Location</th><th>Message</th><th>Fixable</th></tr></thead>
       <tbody>${rowsFor(list)}</tbody>
     </table>`;
   };
@@ -679,7 +815,9 @@ function renderHtml(rep, repoName) {
     padding: 6px 14px; border-radius: 999px; font-weight: 600; font-size: 12px;
     color: #0a0a0a;
   }
-  .kpis { display: grid; grid-template-columns: repeat(6, 1fr); gap: 12px; margin: 24px 0; }
+  .kpis { display: grid; grid-template-columns: repeat(7, 1fr); gap: 12px; margin: 24px 0; }
+  .loc { color: #9ad3ff; text-decoration: none; }
+  .loc:hover { text-decoration: underline; }
   .kpi {
     background: #141414; border: 1px solid #1f1f1f; border-radius: 12px;
     padding: 16px; text-align: center;
@@ -766,6 +904,7 @@ function renderHtml(rep, repoName) {
     <div class="kpi"><div class="label">High</div><div class="value" style="color:${sevColor("HIGH")}">${e(sum.high)}</div></div>
     <div class="kpi"><div class="label">Medium</div><div class="value" style="color:${sevColor("MEDIUM")}">${e(sum.medium)}</div></div>
     <div class="kpi"><div class="label">Low</div><div class="value" style="color:${sevColor("LOW")}">${e(sum.low)}</div></div>
+    <div class="kpi"><div class="label">Unknown</div><div class="value" style="color:${sevColor("UNKNOWN")}">${e(sum.unknown || 0)}</div></div>
   </div>
 
   <h2>Attack surface</h2>
@@ -818,7 +957,12 @@ trivy();
 report.findings = findings;
 
 for (const f of findings) {
-  report.summary[f.severity.toLowerCase()]++;
+  const key = String(f.severity || "UNKNOWN").toLowerCase();
+  if (Object.prototype.hasOwnProperty.call(report.summary, key)) {
+    report.summary[key]++;
+  } else {
+    report.summary.unknown++;
+  }
 }
 
 report.intelligence = analyze(findings);

--- a/test/fixtures/schema/gitleaks.json
+++ b/test/fixtures/schema/gitleaks.json
@@ -1,0 +1,17 @@
+[
+  {
+    "RuleID": "aws-access-key",
+    "Description": "AWS Access Key",
+    "File": "src/config/aws.js",
+    "StartLine": 42,
+    "EndLine": 42,
+    "Match": "AKIAIOSFODNN7EXAMPLE"
+  },
+  {
+    "RuleID": "generic-api-key",
+    "Description": "Generic API Key",
+    "File": "lib/client.ts",
+    "StartLine": 17,
+    "EndLine": 17
+  }
+]

--- a/test/fixtures/schema/npm-audit.json
+++ b/test/fixtures/schema/npm-audit.json
@@ -1,0 +1,19 @@
+{
+  "vulnerabilities": {
+    "lodash": {
+      "name": "lodash",
+      "severity": "high",
+      "title": "Prototype pollution"
+    },
+    "some-pkg": {
+      "name": "some-pkg",
+      "severity": "moderate",
+      "title": "ReDoS"
+    },
+    "weird-pkg": {
+      "name": "weird-pkg",
+      "severity": "frobnicated",
+      "title": "Unknown severity upstream"
+    }
+  }
+}

--- a/test/fixtures/schema/osv.json
+++ b/test/fixtures/schema/osv.json
@@ -1,0 +1,38 @@
+{
+  "results": [
+    {
+      "source": { "path": "package-lock.json", "type": "lockfile" },
+      "packages": [
+        {
+          "package": { "name": "lodash", "ecosystem": "npm", "version": "4.17.10" },
+          "vulnerabilities": [
+            {
+              "id": "GHSA-jf85-cpcp-j695",
+              "summary": "Prototype pollution in lodash",
+              "severity": [
+                { "type": "CVSS_V3", "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H" }
+              ],
+              "database_specific": { "severity": "CRITICAL" }
+            },
+            {
+              "id": "GHSA-xxxx-1234-v3v3",
+              "summary": "Regex DoS in lodash",
+              "severity": [
+                { "type": "CVSS_V3", "score": "7.5/CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H" }
+              ]
+            },
+            {
+              "id": "GHSA-low-rating",
+              "summary": "Low-impact issue",
+              "database_specific": { "severity": "MODERATE" }
+            },
+            {
+              "id": "GHSA-unknown",
+              "summary": "No severity info"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/fixtures/schema/semgrep.json
+++ b/test/fixtures/schema/semgrep.json
@@ -1,0 +1,40 @@
+{
+  "results": [
+    {
+      "check_id": "javascript.lang.security.audit.sqli.node-mysql-sqli",
+      "path": "src/db.js",
+      "start": { "line": 23, "col": 5 },
+      "end": { "line": 25, "col": 20 },
+      "extra": {
+        "severity": "ERROR",
+        "message": "Detected SQL injection",
+        "metadata": { "category": "security", "cwe": ["CWE-89: SQL Injection"] }
+      }
+    },
+    {
+      "check_id": "generic.secrets.security.detected-hardcoded-password",
+      "path": "app/settings.py",
+      "start": { "line": 8, "col": 1 },
+      "end": { "line": 8, "col": 40 },
+      "extra": {
+        "severity": "WARNING",
+        "message": "Hardcoded password detected",
+        "metadata": {
+          "category": "security",
+          "cwe": ["CWE-798: Use of Hard-coded Credentials"]
+        }
+      }
+    },
+    {
+      "check_id": "style.lang.best-practice.unused-var",
+      "path": "src/util.ts",
+      "start": { "line": 100, "col": 3 },
+      "end": { "line": 100, "col": 15 },
+      "extra": {
+        "severity": "INFO",
+        "message": "Unused variable",
+        "metadata": { "category": "best-practice" }
+      }
+    }
+  ]
+}

--- a/test/fixtures/schema/trivy.json
+++ b/test/fixtures/schema/trivy.json
@@ -1,0 +1,24 @@
+{
+  "Results": [
+    {
+      "Target": "Dockerfile",
+      "Misconfigurations": [
+        {
+          "ID": "DS002",
+          "Title": "Image user should not be root",
+          "Description": "Running as root",
+          "Severity": "HIGH",
+          "CauseMetadata": { "StartLine": 5, "EndLine": 5 }
+        }
+      ],
+      "Licenses": [
+        {
+          "Name": "GPL-3.0",
+          "PkgName": "some-pkg",
+          "Severity": "MEDIUM",
+          "FilePath": "vendor/some-pkg/LICENSE"
+        }
+      ]
+    }
+  ]
+}

--- a/test/schema.mjs
+++ b/test/schema.mjs
@@ -1,0 +1,230 @@
+#!/usr/bin/env node
+// Schema unit tests — drive each scanner parser with a stubbed binary that
+// prints a fixture payload, then inspect secgate-v7-report.json.
+
+import { execFileSync } from "child_process";
+import fs from "fs";
+import path from "path";
+import os from "os";
+import { fileURLToPath } from "url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, "..");
+const bin = path.join(repoRoot, "secgate.js");
+const fixDir = path.join(here, "fixtures/schema");
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ok  ${name}`);
+    passed++;
+  } catch (e) {
+    console.log(`  FAIL ${name}`);
+    console.log(`       ${e.message}`);
+    failed++;
+  }
+}
+
+function assert(cond, msg) {
+  if (!cond) throw new Error(msg);
+}
+function assertEq(a, b, msg) {
+  if (a !== b) throw new Error(`${msg}: expected ${JSON.stringify(b)}, got ${JSON.stringify(a)}`);
+}
+
+/**
+ * Run secgate.js against `scanDir` with a PATH prefixed by `stubDir`, so the
+ * given scanner shims override the real binaries.
+ */
+function runWithStubs(scanDir, stubs) {
+  const stubDir = fs.mkdtempSync(path.join(os.tmpdir(), "secgate-stubs-"));
+
+  for (const [name, payload] of Object.entries(stubs)) {
+    const p = path.join(stubDir, name);
+    // Use a POSIX shell shim that prints the payload verbatim.
+    const file = path.join(stubDir, `${name}.json`);
+    fs.writeFileSync(file, payload);
+    fs.writeFileSync(p, `#!/bin/sh\ncat ${JSON.stringify(file)}\n`);
+    fs.chmodSync(p, 0o755);
+  }
+
+  // Also stub `which` lookups by making sure PATH starts with stubDir and
+  // ensure `which`, `node`, `npm` come from the system. PATH prepend is enough.
+  const env = {
+    ...process.env,
+    PATH: `${stubDir}:${process.env.PATH}`
+  };
+
+  let stdout = "";
+  let code = 0;
+  try {
+    stdout = execFileSync("node", [bin, scanDir], {
+      encoding: "utf-8",
+      stdio: "pipe",
+      cwd: scanDir,
+      env
+    });
+  } catch (e) {
+    code = e.status ?? 1;
+    stdout = (e.stdout || "").toString();
+  }
+
+  const reportPath = path.join(scanDir, "secgate-v7-report.json");
+  const report = JSON.parse(fs.readFileSync(reportPath, "utf-8"));
+
+  // cleanup generated report + html
+  try { fs.unlinkSync(reportPath); } catch {}
+  try {
+    const html = path.join(scanDir, `${path.basename(scanDir)}.html`);
+    fs.unlinkSync(html);
+  } catch {}
+  fs.rmSync(stubDir, { recursive: true, force: true });
+
+  return { code, stdout, report };
+}
+
+function scratchDir(suffix) {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), `secgate-${suffix}-`));
+  return d;
+}
+
+function readFixture(name) {
+  return fs.readFileSync(path.join(fixDir, name), "utf-8");
+}
+
+console.log("\nSecGate schema tests");
+console.log("--------------------");
+
+test("gitleaks: extracts file + line + CRITICAL severity", () => {
+  const d = scratchDir("gitleaks");
+  const { report } = runWithStubs(d, { gitleaks: readFixture("gitleaks.json") });
+  const gl = report.findings.filter(f => f.tool === "gitleaks");
+  assertEq(gl.length, 2, "gitleaks finding count");
+  assertEq(gl[0].severity, "CRITICAL", "severity");
+  assertEq(gl[0].file, "src/config/aws.js", "file");
+  assertEq(gl[0].line, 42, "line");
+  assertEq(gl[0].endLine, 42, "endLine");
+  assertEq(gl[0].fixableBy, "manual", "fixableBy");
+  assert(gl[0].fixable === false, "manual fixes should not be flagged fixable");
+  fs.rmSync(d, { recursive: true, force: true });
+});
+
+test("semgrep: tiered severity, secret override, file/line/col", () => {
+  const d = scratchDir("semgrep");
+  // Pass --config=auto so semgrep stub ignores args; shim just prints fixture.
+  const { report } = runWithStubs(d, { semgrep: readFixture("semgrep.json") });
+  const sg = report.findings.filter(f => f.tool === "semgrep");
+  assertEq(sg.length, 3, "semgrep finding count");
+
+  const sqli = sg.find(f => f.signature.includes("sqli"));
+  assertEq(sqli.severity, "HIGH", "ERROR → HIGH");
+  assertEq(sqli.file, "src/db.js", "file");
+  assertEq(sqli.line, 23, "line");
+  assertEq(sqli.col, 5, "col");
+  assertEq(sqli.endLine, 25, "endLine");
+
+  const pwd = sg.find(f => f.signature.includes("hardcoded-password"));
+  assertEq(pwd.severity, "CRITICAL", "hardcoded-password override to CRITICAL");
+  assertEq(pwd.line, 8, "line");
+
+  const info = sg.find(f => f.signature.includes("unused-var"));
+  assertEq(info.severity, "LOW", "INFO → LOW");
+
+  assert(sg.every(f => f.fixable === false), "semgrep must not be auto-fixable");
+  fs.rmSync(d, { recursive: true, force: true });
+});
+
+test("osv: CVSS vector, database_specific, UNKNOWN fallback", () => {
+  const d = scratchDir("osv");
+  const { report } = runWithStubs(d, { "osv-scanner": readFixture("osv.json") });
+  const osv = report.findings.filter(f => f.tool === "osv");
+  assertEq(osv.length, 4, "osv finding count");
+
+  const [crit, ddos, mod, unk] = [
+    osv.find(f => f.signature.includes("GHSA-jf85-cpcp-j695")),
+    osv.find(f => f.signature.includes("GHSA-xxxx-1234-v3v3")),
+    osv.find(f => f.signature.includes("GHSA-low-rating")),
+    osv.find(f => f.signature.includes("GHSA-unknown"))
+  ];
+
+  assertEq(crit.severity, "CRITICAL", "database_specific CRITICAL");
+  assertEq(ddos.severity, "HIGH", "CVSS base 7.5 → HIGH");
+  assertEq(mod.severity, "MEDIUM", "MODERATE → MEDIUM");
+  assertEq(unk.severity, "UNKNOWN", "no info → UNKNOWN");
+
+  for (const f of osv) {
+    assertEq(f.file, "package-lock.json", "lock-file path on all osv findings");
+    assert(f.fixable === false, "osv is not auto-fixable");
+  }
+  fs.rmSync(d, { recursive: true, force: true });
+});
+
+test("trivy: Target as file, CauseMetadata line", () => {
+  const d = scratchDir("trivy");
+  const { report } = runWithStubs(d, { trivy: readFixture("trivy.json") });
+  const tr = report.findings.filter(f => f.tool === "trivy");
+  assertEq(tr.length, 2, "trivy finding count");
+
+  const mis = tr.find(f => f.type === "iac");
+  assertEq(mis.severity, "HIGH", "misconfig severity");
+  assertEq(mis.file, "Dockerfile", "file = Target");
+  assertEq(mis.line, 5, "line from CauseMetadata");
+
+  const lic = tr.find(f => f.type === "license");
+  assertEq(lic.severity, "MEDIUM", "license severity");
+  assertEq(lic.file, "vendor/some-pkg/LICENSE", "license file path");
+  fs.rmSync(d, { recursive: true, force: true });
+});
+
+test("npm audit: lock-file path, auto fixable, unknown severity → UNKNOWN", () => {
+  const d = scratchDir("npm");
+  // npmAudit requires package.json in target.
+  fs.writeFileSync(
+    path.join(d, "package.json"),
+    JSON.stringify({ name: "fx", version: "0.0.0" })
+  );
+  fs.writeFileSync(path.join(d, "package-lock.json"), "{}");
+
+  const { report } = runWithStubs(d, { npm: readFixture("npm-audit.json") });
+  const npm = report.findings.filter(f => f.tool === "npm");
+  assertEq(npm.length, 3, "npm finding count");
+
+  const high = npm.find(f => f.signature === "lodash");
+  assertEq(high.severity, "HIGH", "high");
+  assertEq(high.file, "package-lock.json", "lock file");
+  assertEq(high.fixableBy, "auto", "fixableBy auto");
+  assert(high.fixable === true, "fixable true for npm");
+
+  const mod = npm.find(f => f.signature === "some-pkg");
+  assertEq(mod.severity, "MEDIUM", "moderate → MEDIUM");
+
+  const weird = npm.find(f => f.signature === "weird-pkg");
+  assertEq(weird.severity, "UNKNOWN", "unknown upstream → UNKNOWN");
+
+  assertEq(report.summary.unknown, 1, "unknown counter incremented");
+  fs.rmSync(d, { recursive: true, force: true });
+});
+
+test("summary guards unexpected severity keys (no crash)", () => {
+  const d = scratchDir("guard");
+  fs.writeFileSync(
+    path.join(d, "package.json"),
+    JSON.stringify({ name: "fx", version: "0.0.0" })
+  );
+  const payload = JSON.stringify({
+    vulnerabilities: {
+      "foo": { name: "foo", severity: "bogus", title: "weird" }
+    }
+  });
+  const { report } = runWithStubs(d, { npm: payload });
+  assertEq(report.summary.unknown, 1, "unknown counter");
+  assertEq(report.summary.critical, 0, "critical untouched");
+  fs.rmSync(d, { recursive: true, force: true });
+});
+
+console.log("--------------------");
+console.log(`${passed} passed, ${failed} failed`);
+process.exit(failed === 0 ? 0 : 1);


### PR DESCRIPTION
## Summary

Closes #30.

Single-ingress schema overhaul for `findings[]`. All six epic work items landed in `secgate.js` with fixture-backed unit tests.

**New finding fields:** `file`, `line`, `col`, `endLine`, `fixableBy: "auto" | "manual" | null`. `severity` is normalized to the 5-tier set {CRITICAL, HIGH, MEDIUM, LOW, UNKNOWN}. `summary.unknown` counter added and guarded.

**Per-scanner parsing**
- `gitleaks` — reads `File` + `StartLine` + `EndLine`; always `fixableBy: manual`.
- `semgrep` — 4-tier map (ERROR→HIGH, WARNING→MEDIUM, INFO/NOTE→LOW); overrides to CRITICAL for security-category rules mentioning secrets/creds/tokens or CWE-798/259/321/522. Reads `path`, `start.{line,col}`, `end.line`.
- `osv` — prefers `CVSS_V3`/`CVSS_V2` base score (stripping the `CVSS:3.1/` version prefix so it's not mistaken for the score), then `database_specific.severity`, then any rating text; falls back to UNKNOWN. Lock-file path from `source.path`.
- `trivy` — `Target` as file, `CauseMetadata.StartLine/EndLine` for misconfigs; `FilePath` or `Target` for licenses.
- `npm` — lock-file path (prefers `package-lock.json`), `fixableBy: "auto"` since `patch()` returns an `exec`; normalization catches `moderate` → MEDIUM and unknown upstream strings → UNKNOWN.

**HTML report**
- New "Unknown" KPI card (grid widened to 7 cols).
- Findings table gains a **Location** column with clickable `file://` links when the path is absolute.
- Fixable column now renders `auto` / `manual` / `no`.

**Tests**
- 6 new unit tests in `test/schema.mjs` using PATH-stubbed scanner shims that print fixtures from `test/fixtures/schema/*.json`. Each asserts `{ file, line, severity, fixableBy }`. Includes an unknown-severity-upstream → UNKNOWN counter regression.
- All 9 existing smoke tests still pass.

**README** — schema block updated with new fields + severity-tier + fixability docs.

Does **not** touch the `--apply` file-write path (avoiding conflict with #29).

## Test plan

- [x] `npm run test:smoke` — 9/9
- [x] `npm run test:schema` — 6/6
- [x] `npm test` — 15/15
- [x] End-to-end: `node secgate.js test/fixtures/clean` → clean report with `summary.unknown: 0`.