### PR TITLE
chore(core): cleanup follow-ups from PR #42 lib/ extraction

### DIFF
--- a/lib/baseline.mjs
+++ b/lib/baseline.mjs
@@ -10,7 +10,10 @@ export function loadBaseline(config, target) {
 
   try {
     const raw = JSON.parse(fs.readFileSync(baselinePath, "utf-8"));
-    if (!Array.isArray(raw.findings)) return null;
+    if (!Array.isArray(raw.findings)) {
+      console.error(`[secgate] Baseline file ${baselinePath} missing 'findings' array — ignoring`);
+      return null;
+    }
     return raw;
   } catch {
     console.error(`[secgate] Could not parse baseline file: ${baselinePath}`);

--- a/lib/intelligence.mjs
+++ b/lib/intelligence.mjs
@@ -52,7 +52,7 @@ export function patch(f) {
   if (f.tool === "npm") {
     return {
       action: "npm audit fix",
-      cmd: `npm audit fix --ignore-scripts (cwd=${f.file ? f.file : "target"})`,
+      cmd: null,
       exec: {
         binary: "npm",
         args: ["audit", "fix", "--ignore-scripts"],

--- a/lib/report.mjs
+++ b/lib/report.mjs
@@ -500,7 +500,10 @@ export function buildSarif(rep, repoName, baseDir) {
     });
 
     const binary  = toolKey === "osv" ? "osv-scanner" : toolKey === "npm" ? null : toolKey === "trivyImage" ? "trivy" : toolKey;
-    const version = binary ? toolVersion(binary) : "unknown";
+    const status  = rep.tools[toolKey] || "pending";
+    const version = (binary && status !== "skipped" && status !== "pending")
+      ? toolVersion(binary)
+      : "unknown";
 
     return {
       tool: {

--- a/lib/scanners.mjs
+++ b/lib/scanners.mjs
@@ -10,7 +10,7 @@ const SEMGREP_TIER = {
 };
 
 const SECRET_RE = /(secret|credential|password|token|api[_-]?key|hardcoded)/i;
-const SECRET_CWES = ["CWE-798", "CWE-259", "CWE-321", "CWE-522", "CWE-798:"];
+const SECRET_CWES = ["CWE-798", "CWE-259", "CWE-321", "CWE-522"];
 
 function semgrepSeverity(r) {
   const base = SEMGREP_TIER[(r.extra?.severity || "").toUpperCase()] || "MEDIUM";
@@ -139,7 +139,7 @@ export function hasInlineSuppression(filePath, lineNumber, ruleId) {
     const m = line.match(suppressRe);
     if (m) {
       const suppressedRule = m[1];
-      if (matchPattern(suppressedRule, ruleId) || suppressedRule === ruleId) {
+      if (matchPattern(suppressedRule, ruleId)) {
         return suppressedRule;
       }
     }
@@ -355,7 +355,7 @@ export function runTrivy(target, config, addFinding, debugFn) {
     "--quiet",
     "--format", "json",
     "--scanners", "misconfig,license",
-    "--skip-dirs", "**/test/fixtures",
+    ...(process.env.SECGATE_INTERNAL_TEST === "1" ? ["--skip-dirs", "**/test/fixtures"] : []),
     "--skip-dirs", "**/node_modules",
     target
   ]);
@@ -404,11 +404,15 @@ export function runTrivy(target, config, addFinding, debugFn) {
 }
 
 export function runTrivyImage(target, config, addFinding, debugFn) {
+  if (config.scanners.trivy === false) {
+    return { status: "skipped", skipReason: "disabled in config" };
+  }
   if (!toolExists("trivy")) {
     return { status: "skipped" };
   }
 
-  const dockerfiles = findDockerfiles(target).filter(f => !f.includes("/test/fixtures"));
+  const isInternalTest = process.env.SECGATE_INTERNAL_TEST === "1";
+  const dockerfiles = findDockerfiles(target).filter(f => !isInternalTest || !f.includes("/test/fixtures"));
   if (dockerfiles.length === 0) return { status: "skipped" };
 
   const imageRefs = new Set();

--- a/package.json
+++ b/package.json
@@ -48,8 +48,8 @@
     "provenance": true
   },
   "scripts": {
-    "test": "node test/engine.mjs && node test/smoke.mjs && node test/schema.mjs && node test/sarif.mjs && node test/trivy-image.mjs && node test/no-lockfile.mjs && node test/config.mjs && node test/baseline.mjs && node test/suppression.mjs",
-    "test:smoke": "node test/smoke.mjs",
+    "test": "node test/engine.mjs && SECGATE_INTERNAL_TEST=1 node test/smoke.mjs && node test/schema.mjs && node test/sarif.mjs && node test/trivy-image.mjs && node test/no-lockfile.mjs && node test/config.mjs && node test/baseline.mjs && node test/suppression.mjs",
+    "test:smoke": "SECGATE_INTERNAL_TEST=1 node test/smoke.mjs",
     "test:schema": "node test/schema.mjs",
     "test:sarif": "node test/sarif.mjs",
     "test:trivy-image": "node test/trivy-image.mjs",

--- a/secgate.js
+++ b/secgate.js
@@ -208,7 +208,7 @@ function confirmApplyOrExit() {
     );
     let answer = "";
     try {
-      const buf = Buffer.alloc(8);
+      const buf = Buffer.alloc(64);
       const n = fs.readSync(0, buf, 0, buf.length, null);
       answer = buf.slice(0, n).toString("utf-8").trim().toLowerCase();
     } catch {

--- a/test/baseline.mjs
+++ b/test/baseline.mjs
@@ -213,6 +213,32 @@ test("config.baselineFile: custom path used for read/write", () => {
   fs.rmSync(stubDir, { recursive: true, force: true });
 });
 
+// ── loadBaseline: malformed shape warns and treats all findings as net-new ────
+
+test("loadBaseline: malformed baseline shape logs warning, all findings net-new", () => {
+  const d = scratch("malformed-bl");
+  const stubDir = setupScanDir(d, PKG_A);
+
+  fs.writeFileSync(path.join(d, ".secgate-baseline.json"), JSON.stringify({ foo: 1 }));
+
+  let stderr = "";
+  try {
+    execFileSync("node", [bin, d, "--baseline"], {
+      encoding: "utf-8",
+      stdio: "pipe",
+      cwd: d,
+      env: { ...process.env, PATH: `${stubDir}:${process.env.PATH}` }
+    });
+  } catch (e) {
+    stderr = (e.stderr || "").toString();
+  }
+
+  assert(stderr.includes("missing 'findings' array"), "stderr warns about malformed baseline shape");
+
+  fs.rmSync(d, { recursive: true, force: true });
+  fs.rmSync(stubDir, { recursive: true, force: true });
+});
+
 // ── --baseline with no baseline file treats all as net-new ────────────────────
 
 test("--baseline with no baseline file: all findings are net-new", () => {

--- a/test/trivy-image.mjs
+++ b/test/trivy-image.mjs
@@ -209,8 +209,34 @@ test("node_modules Dockerfiles are not walked", () => {
   const emptyResult = JSON.stringify({ Results: [] });
   const { report } = runWithStubs(d, { trivy: emptyResult });
 
-  // No Dockerfiles found outside node_modules → trivyImage skipped
   assertEq(report.tools.trivyImage, "skipped", "trivyImage skipped when Dockerfile only in node_modules");
+  fs.rmSync(d, { recursive: true, force: true });
+});
+
+test("scanners.trivy: false in config → trivyImage skipped", () => {
+  const d = scratchDir("img-trivy-disabled");
+  fs.writeFileSync(path.join(d, "Dockerfile"), "FROM python:3.8\n");
+  fs.writeFileSync(path.join(d, ".secgate.config.json"), JSON.stringify({
+    scanners: { trivy: false }
+  }));
+
+  const emptyResult = JSON.stringify({ Results: [] });
+  const { report } = runWithStubs(d, { trivy: emptyResult });
+
+  assertEq(report.tools.trivyImage, "skipped", "trivyImage skipped when trivy disabled in config");
+  fs.rmSync(d, { recursive: true, force: true });
+});
+
+test("user repo with test/fixtures/Dockerfile is scanned (no false-positive path skip)", () => {
+  const d = scratchDir("img-user-fixtures");
+  const fixtureDir = path.join(d, "test", "fixtures");
+  fs.mkdirSync(fixtureDir, { recursive: true });
+  fs.writeFileSync(path.join(fixtureDir, "Dockerfile"), "FROM alpine:3.18\n");
+
+  const emptyResult = JSON.stringify({ Results: [] });
+  const { report } = runWithStubs(d, { trivy: emptyResult });
+
+  assertEq(report.tools.trivyImage, "clean", "trivyImage scans Dockerfiles in user test/fixtures dir");
   fs.rmSync(d, { recursive: true, force: true });
 });
 


### PR DESCRIPTION
## Summary

- `runTrivyImage` now respects `scanners.trivy === false` in config (was always running regardless)
- Removed redundant `CWE-798:` entry from `SECRET_CWES` array
- Removed dead `|| suppressedRule === ruleId` in suppression check (`matchPattern` already handles literal equality)
- `patch()` npm entry initializes `cmd: null`; `remediate()` populates it with correct cwd context
- `buildSarif` skips `toolVersion()` exec for skipped/pending tools (worst-case was 6 × 5s = 30s latency)
- `test/fixtures` path filter in `runTrivy`/`runTrivyImage` now scoped to `SECGATE_INTERNAL_TEST=1` — eliminates false-positive skips in user repos with `test/fixtures/` dirs
- `loadBaseline` warns on malformed shape (valid JSON but missing `findings` array) instead of silently returning null
- Confirm-apply read buffer bumped 8 → 64 bytes (prevents truncation of "yes" variations)

Fix #5 (`runTool` swallows exit codes) deferred — larger refactor, separate PR.

## Test plan

- [x] All 9 test suites pass (`npm test`)
- [x] New test: `scanners.trivy: false` → `trivyImage` skipped
- [x] New test: user repo `test/fixtures/Dockerfile` IS scanned (no false-positive path skip)
- [x] New test: malformed baseline shape logs warning to stderr
- [x] No behavior change to existing passing scenarios

Closes #43

🤖 Generated with [Claude Code](https://claude.ai/claude-code)