### PR TITLE
chore(release): v0.2.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
 > **SecGate** is a tiny security gate for CI/CD. Runs **Semgrep, Gitleaks, osv-scanner, Trivy, and npm audit** in one command, normalizes findings into one report, fails the pipeline on CRITICAL or HIGH. No account. No telemetry. Local files only.
 
-> **Status:** Early release (`v0.2.3`). Published with [npm provenance](https://docs.npmjs.com/generating-provenance-statements). Report vulnerabilities via [SECURITY.md](SECURITY.md).
+> **Status:** Early release (`v0.2.4`). Published with [npm provenance](https://docs.npmjs.com/generating-provenance-statements). Report vulnerabilities via [SECURITY.md](SECURITY.md).
 
 ---
 
@@ -394,7 +394,7 @@ Each run writes:
 
 ```json
 {
-  "version": "0.2.3",
+  "version": "0.2.4",
   "timestamp": "ISO 8601",
   "target": "/absolute/path",
   "mode": "dry-run | apply",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinydarkforge/secgate",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Tiny security gate for CI/CD — orchestrates Semgrep, Gitleaks, osv-scanner, Trivy, and npm audit with a premium HTML report.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- Bumps package version `0.2.3` → `0.2.4`
- Updates README status line and JSON schema example to reflect new version

Release contents: docs/CLI banner refresh from #45. No behavior changes.

## Test plan
- [x] `npm test` green on main
- [ ] After merge: tag `v0.2.4` on main → release.yml builds SBOM + cosign signatures + SLSA L3 attestation + publishes to npm with provenance