### PR TITLE
docs(roadmap): mark Lucen-era doc as legacy

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,4 +1,12 @@
 # Roadmap — Lucen + SecGate
+
+> ⚠️ **LEGACY DOC — Lucen-era (2026-04-22).**
+> "Lucen" was renamed to **LuxScope**. SecGate is now maintenance-only legacy track; enterprise tier deferred to Year 2 (post-1k LuxScope paying users).
+> Current truth: `../../docs/ROADMAP.md` (Stelnyx-root) + LuxScope epic [#286](https://github.com/Stelnyx/LuxScope/issues/286).
+> Kept for historical reference; do not act on it.
+
+---
+
 **Last updated:** 2026-04-22
 **Strategy reference:** `docs/business-analysis.md`
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,7 +2,7 @@
 
 > ⚠️ **LEGACY DOC — Lucen-era (2026-04-22).**
 > "Lucen" was renamed to **LuxScope**. SecGate is now maintenance-only legacy track; enterprise tier deferred to Year 2 (post-1k LuxScope paying users).
-> Current truth: `../../docs/ROADMAP.md` (Stelnyx-root) + LuxScope epic [#286](https://github.com/Stelnyx/LuxScope/issues/286).
+> Current truth: [Stelnyx/web — docs/ROADMAP.md](https://github.com/Stelnyx/web/blob/main/docs/ROADMAP.md) + LuxScope epic [#286](https://github.com/Stelnyx/LuxScope/issues/286).
 > Kept for historical reference; do not act on it.
 
 ---


### PR DESCRIPTION
## Summary
- Banner on `docs/roadmap.md` flagging it as Lucen-era (renamed to LuxScope)
- Point to LuxScope epics #286 / #287 + new root `stelnix/docs/ROADMAP.md`
- Doc retained for historical reference (SecGate is maintenance-only legacy track)

## Why
SecGate roadmap dated 2026-04-22, calls product "Lucen" — renamed to LuxScope 5+ weeks ago. SecGate enterprise tier deferred to Year 2 (post-1k LuxScope paying users).

## Test plan
- [ ] Render `docs/roadmap.md` — banner visible
- [ ] No broken cross-repo links